### PR TITLE
Fix 400 errors: increase DB connection pool size

### DIFF
--- a/viz/backend/src/model/db.rs
+++ b/viz/backend/src/model/db.rs
@@ -3,7 +3,7 @@ use sqlx::{Pool, Postgres};
 use std::time::Duration;
 use dotenv::dotenv;
 
-const PG_APP_MAX_CON: u32 = 5;
+const PG_APP_MAX_CON: u32 = 20;
 
 pub type Db = Pool<Postgres>;
 
@@ -27,7 +27,7 @@ async fn new_db_pool(host: std::string::String, db: std::string::String, user: s
 	println!("con_string: {}", con_string);
 	PgPoolOptions::new()
 		.max_connections(max_con)
-		.acquire_timeout(Duration::from_millis(500)) // Needs to find replacement
+		.acquire_timeout(Duration::from_millis(5000))
 		.connect(&con_string)
 		.await
 }


### PR DESCRIPTION
## Summary
- Increased DB connection pool from 5 to 20 max connections
- Increased acquire timeout from 500ms to 5s
- Fixes `pool timed out while waiting for an open connection` errors that caused 400s on the frontend when loading all metrics simultaneously

## Context
The frontend fires 50+ API requests on page load (one per metric). With only 5 pool connections and a 500ms timeout, requests that couldn't grab a connection in time failed with 400. Affected endpoints included `whoopMaxHeartRate`, `intermittentFast`, `whoopSpO2`, `whoopSleepConsistency`, etc.

## Test plan
- [ ] Merge and let CI build the new `dementor/matrix-viz` image
- [ ] Pull and restart viz container on the server: `docker pull dementor/matrix-viz:latest && docker restart fxlifesheet_viz_1`
- [ ] Load metrics.soumyadeep.in and verify no 400 errors in browser console

🤖 Generated with [Claude Code](https://claude.com/claude-code)