### PR TITLE
Fix critical security issues across bot, viz backend, and infra

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -18,7 +18,7 @@ services:
     restart: always
     environment:
       - POSTGRES_USER=soumyadeepmukherjee
-      - POSTGRES_PASSWORD=ILovePostgres
+      - POSTGRES_PASSWORD=${POSTGRES_PASSWORD}
     volumes:
       - ./db:/docker-entrypoint-initdb.d
       - ./data:/var/lib/postgresql/data

--- a/telegram_bot/src/worker.ts
+++ b/telegram_bot/src/worker.ts
@@ -66,7 +66,7 @@ function printGraph(
       console.log(res);
       if (err) {
         console.error(err);
-        ctx.reply(err);
+        ctx.reply("An error occurred while fetching data. Please try again.");
         return;
       }
 
@@ -602,6 +602,19 @@ function initBot() {
     }
 
     let key = ctx.match[1];
+
+    // Validate key exists in config to prevent arbitrary input in SQL
+    let validKeys = [];
+    for (let section in config.userConfig) {
+      for (let q of config.userConfig[section].questions || []) {
+        if (q.key) validKeys.push(q.key);
+      }
+    }
+    if (!validKeys.includes(key)) {
+      ctx.reply("Unknown metric key: " + key);
+      return;
+    }
+
     console.log("User wants to graph a specific value " + key);
 
     printGraph(key, ctx, 100, null, false);

--- a/viz/backend/src/model/db.rs
+++ b/viz/backend/src/model/db.rs
@@ -10,10 +10,6 @@ pub type Db = Pool<Postgres>;
 pub async fn init_db() -> Result<Db, sqlx::Error> {
 	dotenv().ok();
 	
-	for (key, value) in std::env::vars() {
-		println!("{key}: {value}");
-	}
-	
 	let host = std::env::var("HOST").unwrap_or("localhost".to_string());
 	let db_name = std::env::var("DB_NAME").unwrap_or("viz".to_string());
 	let db_user = std::env::var("DB_USER").unwrap_or("viz".to_string());
@@ -24,7 +20,7 @@ pub async fn init_db() -> Result<Db, sqlx::Error> {
 
 async fn new_db_pool(host: std::string::String, db: std::string::String, user: std::string::String, pwd: std::string::String, max_con: u32) -> Result<Db, sqlx::Error> {
 	let con_string = format!("postgres://{}:{}@{}/{}", user, pwd, host, db);
-	println!("con_string: {}", con_string);
+	println!("Connecting to db at {}", host);
 	PgPoolOptions::new()
 		.max_connections(max_con)
 		.acquire_timeout(Duration::from_millis(500)) // Needs to find replacement

--- a/viz/backend/src/model/raw_data_dao.rs
+++ b/viz/backend/src/model/raw_data_dao.rs
@@ -37,13 +37,6 @@ impl RawData {
 		Ok(data_by_key)
 	}
 
-	pub async fn list(db: &Db) -> Result<Vec<RawDataObj>, model::Error> {
-		let sb = sqlb::select().table(Self::TABLE).columns(Self::COLUMNS);
-
-		// execute the query
-		let raw_data = sb.fetch_all(db).await?;
-		Ok(raw_data)
-	}
 }
 // endregion: TodoMac
 

--- a/viz/backend/src/web/mod.rs
+++ b/viz/backend/src/web/mod.rs
@@ -25,7 +25,9 @@ pub async fn start_web(web_port: u16, db: Arc<Db>) -> Result<(), Error> {
 	let static_s = warp::fs::dir("../frontend/build/");
 	// Combine all routes
 
-	let cors = warp::cors().allow_any_origin();
+	let cors = warp::cors()
+		.allow_origin("https://metrics.soumyadeep.in")
+		.allow_methods(vec!["GET"]);
 	let log = warp::log("access");
 
 	// Combine all routes

--- a/viz/backend/src/web/raw_data.rs
+++ b/viz/backend/src/web/raw_data.rs
@@ -13,32 +13,13 @@ pub fn raw_data_rest_filters(
 	// let common = super::filter_utils::with_db(db.clone()).and(do_auth(db.clone()));
 	let common = super::filter_utils::with_db(db.clone());
 
-	// LIST raw_data `GET data/`
-	let list = data_path
-		.and(warp::get())
-		.and(warp::path::end())
-		.and(common.clone())
-		.and_then(data_get_all);
-
-	// // GET todo `GET /todos/100`
-	// let get = data_path
-	// 	.and(warp::get())
-	// 	.and(common.clone())
-	// 	.and(warp::path::param())
-	// 	.and_then(data_get);
-
 	let get = data_path
 		.and(warp::get())
 		.and(common.clone())
 		.and(warp::path::param())
 		.and_then(data_get_by_key);
 
-	list.or(get)
-}
-
-async fn data_get_all(db: Arc<Db>) -> Result<Json, warp::Rejection> {
-	let raw_data = RawData::list(&db).await?;
-	json_response(raw_data)
+	get
 }
 
 async fn data_get_by_key(db: Arc<Db>, key: String) -> Result<Json, warp::Rejection> {


### PR DESCRIPTION
## Summary
- **Bot: Validate `/graph` key** — reject unknown metric keys before they reach SQL string interpolation
- **Viz backend: Stop logging credentials** — remove env var dump and mask password in connection log
- **Viz backend: Restrict CORS** — lock down to `https://metrics.soumyadeep.in` with GET only
- **Viz backend: Remove `GET /api/data/` list-all endpoint** — unauthenticated full database dump no longer possible
- **Bot: Sanitize error messages** — stop leaking raw DB errors to Telegram users
- **Docker: Externalize DB password** — reference `${POSTGRES_PASSWORD}` env var instead of hardcoded plaintext

## Test plan
- [ ] Send `/graph invalidkey123` in Telegram → should get "Unknown metric key" response
- [ ] Send `/graph mood` → should still work as before
- [ ] `curl https://metrics.soumyadeep.in/api/data/mood` → 200 with data
- [ ] `curl https://metrics.soumyadeep.in/api/data/` → 404 or error (no list-all)
- [ ] Check `docker logs` for viz container → no password in output
- [ ] `curl -H "Origin: https://evil.com" -I https://metrics.soumyadeep.in/api/data/mood` → no CORS header
- [ ] Ensure `POSTGRES_PASSWORD` is set in env or `.env` file before `docker-compose up`

🤖 Generated with [Claude Code](https://claude.com/claude-code)