### PR TITLE
feat: whiteboard UI redesign

### DIFF
--- a/viz/frontend/package.json
+++ b/viz/frontend/package.json
@@ -47,5 +47,6 @@
     "jest": "^29.5.0",
     "sass": "^1.62.0",
     "ts-jest": "^29.1.0"
-  }
+  },
+  "homepage": "https://sam17.github.io/FxLifeSheet"
 }

--- a/viz/frontend/src/App.scss
+++ b/viz/frontend/src/App.scss
@@ -1,30 +1,73 @@
-.svg {
-  svg {
-      rect {
-          fill: orange;
-      }
+.App {
+  padding: 40px 48px;
+  max-width: 1400px;
+  margin: 0 auto;
+}
 
-      text {
-          fill: white;
-          font: 10px sans-serif;
-          text-anchor: end;
-      }
+.app-header {
+  margin-bottom: 8px;
+
+  h1 {
+    font-family: 'Inter', sans-serif;
+    font-size: 2rem;
+    font-weight: 600;
+    color: #1a1a1a;
+    margin: 0;
+    letter-spacing: -0.5px;
   }
 }
 
-.App {
-  padding: 30px;
-}
-
 .dateHeading {
-  font-size: 18px;
-  font-weight: normal;
-  margin-bottom: 10px;
-  color: #666666;
+  font-size: 15px;
+  font-weight: 400;
+  margin-bottom: 32px;
+  color: #888;
+  letter-spacing: 0.01em;
 }
 
-ant-divider {
-    background-color: #111;
-    font-size: 100px !important;
-    border-top: 1px #111 !important;
+.section-label {
+  font-size: 11px;
+  font-weight: 600;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: #aaa;
+  margin: 32px 0 16px 0;
+  padding-left: 2px;
+  display: flex;
+  align-items: center;
+  gap: 10px;
+
+  &::after {
+    content: '';
+    flex: 1;
+    height: 1px;
+    background: #e8e6e0;
+  }
+}
+
+.metric-card {
+  background: #ffffff;
+  border: 1.5px solid #e8e6e0;
+  border-radius: 12px;
+  padding: 18px 20px 14px;
+  box-shadow: 2px 3px 0px #e0ded8;
+  transition: box-shadow 0.15s ease, transform 0.15s ease;
+
+  &:hover {
+    box-shadow: 3px 5px 0px #d4d1cb;
+    transform: translateY(-1px);
+  }
+
+  .metric-card-title {
+    font-size: 11px;
+    font-weight: 600;
+    color: #999;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    margin-bottom: 10px;
+  }
+}
+
+.ant-divider {
+  border-color: transparent !important;
 }

--- a/viz/frontend/src/App.scss
+++ b/viz/frontend/src/App.scss
@@ -1,73 +1,68 @@
 .App {
-  padding: 40px 48px;
+  padding: 48px 60px;
   max-width: 1400px;
   margin: 0 auto;
 }
 
 .app-header {
-  margin-bottom: 8px;
+  margin-bottom: 4px;
 
   h1 {
-    font-family: 'Inter', sans-serif;
-    font-size: 2rem;
-    font-weight: 600;
-    color: #1a1a1a;
+    font-family: 'Patrick Hand', cursive;
+    font-size: 2.2rem;
+    font-weight: 400;
+    color: #111;
     margin: 0;
-    letter-spacing: -0.5px;
   }
 }
 
 .dateHeading {
-  font-size: 15px;
+  font-family: 'Patrick Hand', cursive;
+  font-size: 16px;
   font-weight: 400;
-  margin-bottom: 32px;
-  color: #888;
-  letter-spacing: 0.01em;
+  margin-bottom: 44px;
+  color: #777;
 }
 
+/* Section header: underlined marker text, not a full-width rule */
 .section-label {
-  font-size: 11px;
-  font-weight: 600;
-  letter-spacing: 0.12em;
+  font-family: 'Patrick Hand', cursive;
+  font-size: 1.15rem;
+  font-weight: 400;
+  color: #222;
+  margin: 44px 0 18px 0;
+  letter-spacing: 0.08em;
   text-transform: uppercase;
-  color: #aaa;
-  margin: 32px 0 16px 0;
-  padding-left: 2px;
-  display: flex;
-  align-items: center;
-  gap: 10px;
-
-  &::after {
-    content: '';
-    flex: 1;
-    height: 1px;
-    background: #e8e6e0;
+  display: inline-block;
+  border-bottom: 2px solid #222;
+  padding-bottom: 2px;
+  /* Display as block after so the grid follows */
+  & + * {
+    clear: both;
   }
+}
+
+/* Section wrapper to make label full-width then grid */
+.section-wrapper {
+  margin-bottom: 8px;
 }
 
 .metric-card {
-  background: #ffffff;
-  border: 1.5px solid #e8e6e0;
-  border-radius: 12px;
-  padding: 18px 20px 14px;
-  box-shadow: 2px 3px 0px #e0ded8;
-  transition: box-shadow 0.15s ease, transform 0.15s ease;
-
-  &:hover {
-    box-shadow: 3px 5px 0px #d4d1cb;
-    transform: translateY(-1px);
-  }
+  background: #fff;
+  /* pencil-sketch style border */
+  border: 1px solid #c8c8c8;
+  border-radius: 3px;
+  padding: 16px 16px 10px;
+  box-shadow: 1px 1px 0 #e0e0e0, 2px 2px 0 #ebebeb;
 
   .metric-card-title {
-    font-size: 11px;
-    font-weight: 600;
-    color: #999;
-    letter-spacing: 0.08em;
-    text-transform: uppercase;
-    margin-bottom: 10px;
+    font-family: 'Patrick Hand', cursive;
+    font-size: 14px;
+    font-weight: 400;
+    color: #666;
+    margin-bottom: 6px;
+    letter-spacing: 0.02em;
   }
 }
 
-.ant-divider {
-  border-color: transparent !important;
-}
+.ant-divider { border-color: transparent !important; }

--- a/viz/frontend/src/App.tsx
+++ b/viz/frontend/src/App.tsx
@@ -26,13 +26,11 @@ function App() {
 
   return (
     <div className="App">
-      <h1>
-        <center> How is {name}? 🤔</center>
-      </h1>
+      <div className="app-header">
+        <h1>How is {name}? 🤔</h1>
+      </div>
       <div className="dateHeading">
-        <center>
-          <DateElement></DateElement>
-        </center>
+        <DateElement></DateElement>
       </div>
       <VizBuilder baseUrl={baseUrl}></VizBuilder>
     </div>

--- a/viz/frontend/src/App.tsx
+++ b/viz/frontend/src/App.tsx
@@ -5,12 +5,7 @@ import DateElement from "./components/DateElements";
 
 function App() {
   const [name, setName] = useState("unnamed");
-  const development: boolean =
-    !process.env.NODE_ENV || process.env.NODE_ENV === "development";
-  const baseUrl: string = development
-    // ? "http://localhost:8080/api/"
-    ? "https://metrics.soumyadeep.in/api/"
-    : "/api/";
+  const baseUrl: string = process.env.REACT_APP_API_URL || "/api/";
 
   useEffect(() => {
     fetch(baseUrl + "metadata")

--- a/viz/frontend/src/components/CalendarViz.tsx
+++ b/viz/frontend/src/components/CalendarViz.tsx
@@ -1,7 +1,6 @@
 import React from "react";
 import * as d3 from "d3";
 import { Col } from "antd";
-import styles from "../stylesheets.module.scss";
 import { ArrayDateData, RawDateData } from "src/models/date_data";
 import { getLastDateToBeShownInViz, getStartDateToBeShownInViz, weeksToShowInViz, getContinuousDates } from "src/utils/date";
 import {viz_details} from "../models/constants";

--- a/viz/frontend/src/components/CalendarViz.tsx
+++ b/viz/frontend/src/components/CalendarViz.tsx
@@ -178,17 +178,17 @@ class CalendarViz extends React.Component<IProps, IState> {
 
   render() {
     return (
-      <Col xxl={6} xl={8} lg={8} md={12} sm={24} xs={24} >
-      <div className={this.name}>
-        <h2 className={styles.vizHeading}>{this.displayName}</h2>
-        <svg
-          className="container"
-          ref={(ref: SVGSVGElement) => (this.ref = ref)}
-          width="0"
-          height="0"
-        ></svg>
-      </div>
-    </Col>
+      <Col xxl={6} xl={8} lg={8} md={12} sm={24} xs={24}>
+        <div className="metric-card">
+          <div className="metric-card-title">{this.displayName}</div>
+          <svg
+            className="container"
+            ref={(ref: SVGSVGElement) => (this.ref = ref)}
+            width="0"
+            height="0"
+          ></svg>
+        </div>
+      </Col>
     );
   }
 }

--- a/viz/frontend/src/components/CalendarViz.tsx
+++ b/viz/frontend/src/components/CalendarViz.tsx
@@ -179,7 +179,7 @@ class CalendarViz extends React.Component<IProps, IState> {
   render() {
     return (
       <Col xxl={6} xl={8} lg={8} md={12} sm={24} xs={24}>
-        <div className="metric-card">
+        <div className={"metric-card " + this.name}>
           <div className="metric-card-title">{this.displayName}</div>
           <svg
             className="container"

--- a/viz/frontend/src/components/LineChartViz.tsx
+++ b/viz/frontend/src/components/LineChartViz.tsx
@@ -42,13 +42,13 @@ class LineChartViz extends React.Component<IProps, IState> {
     const x = d3.scaleTime().range([0, width]);
     const y = d3.scaleLinear().range([height, 0]);
 
-    const positiveColor = "#375F1B";
-    const negativeColor = "#5F1B1B";
+    const positiveColor = "#4A90D9";
+    const negativeColor = "#E07B5A";
 
     const colour = this.isPositive ? positiveColor : negativeColor;
 
-    const positiveColorDark = "#1B3409";
-    const negativeColorDark = "#340909";
+    const positiveColorDark = "#2C6FAD";
+    const negativeColorDark = "#C05A3A";
 
     const colourDark = this.isPositive ? positiveColorDark : negativeColorDark;
     let lastDayForViz = getLastDateToBeShownInViz(new Date());
@@ -175,8 +175,8 @@ class LineChartViz extends React.Component<IProps, IState> {
   render() {
     return (
       <Col xxl={6} xl={8} lg={8} md={12} sm={24} xs={24}>
-        <div className={this.name + "12"}>
-          <h2 className={styles.vizHeading}>{this.displayName}</h2>
+        <div className="metric-card">
+          <div className="metric-card-title">{this.displayName}</div>
           <svg
             className="container"
             ref={(ref: SVGSVGElement) => (this.ref = ref)}

--- a/viz/frontend/src/components/LineChartViz.tsx
+++ b/viz/frontend/src/components/LineChartViz.tsx
@@ -1,7 +1,6 @@
 import React from "react";
 import * as d3 from "d3";
 import { Col } from "antd";
-import styles from "../stylesheets.module.scss";
 import { ArrayDateData, RawDateData } from "src/models/date_data";
 import {
   getLastDateToBeShownInViz,

--- a/viz/frontend/src/components/LineChartViz.tsx
+++ b/viz/frontend/src/components/LineChartViz.tsx
@@ -42,13 +42,13 @@ class LineChartViz extends React.Component<IProps, IState> {
     const x = d3.scaleTime().range([0, width]);
     const y = d3.scaleLinear().range([height, 0]);
 
-    const positiveColor = "#4A90D9";
-    const negativeColor = "#E07B5A";
+    const positiveColor = "#2563a8"; // ink blue
+    const negativeColor = "#c0392b"; // ink red
 
     const colour = this.isPositive ? positiveColor : negativeColor;
 
-    const positiveColorDark = "#2C6FAD";
-    const negativeColorDark = "#C05A3A";
+    const positiveColorDark = "#1a4a8a";
+    const negativeColorDark = "#a93226";
 
     const colourDark = this.isPositive ? positiveColorDark : negativeColorDark;
     let lastDayForViz = getLastDateToBeShownInViz(new Date());
@@ -126,7 +126,9 @@ class LineChartViz extends React.Component<IProps, IState> {
         .attr("d", line)
         .style("fill", "none")
         .style("stroke", colour)
-        .style("stroke-width", 1.7);
+        .style("stroke-width", 2.8) // thick marker stroke
+        .style("stroke-linecap", "round")
+        .style("stroke-linejoin", "round");
 
       svg
         .selectAll(".dot")
@@ -175,7 +177,7 @@ class LineChartViz extends React.Component<IProps, IState> {
   render() {
     return (
       <Col xxl={6} xl={8} lg={8} md={12} sm={24} xs={24}>
-        <div className="metric-card">
+        <div className={"metric-card " + this.name + "12"}>
           <div className="metric-card-title">{this.displayName}</div>
           <svg
             className="container"

--- a/viz/frontend/src/components/VizBuilder.tsx
+++ b/viz/frontend/src/components/VizBuilder.tsx
@@ -1,7 +1,6 @@
 import React, { useEffect, useState } from "react";
 import CategoryData from "../models/category_data";
 import QuestionData from "../models/question_data";
-import styles from "../stylesheets.module.scss";
 import { Row } from "antd";
 import CalendarViz from "./CalendarViz";
 import LineChartViz from "./LineChartViz";

--- a/viz/frontend/src/components/VizBuilder.tsx
+++ b/viz/frontend/src/components/VizBuilder.tsx
@@ -68,7 +68,9 @@ function VizBuilder(props: props) {
       {questionsForCategory.map((item) => {
         return (
           <div key={item.category}>
-            <div className="section-label">{item.category}</div>
+            <div style={{display:'block'}}>
+            <span className="section-label">{item.category}</span>
+          </div>
             <Row gutter={[16, 16]}>
               {item.questions.map((question) => {
                 if (question.graph_type === "line") {

--- a/viz/frontend/src/components/VizBuilder.tsx
+++ b/viz/frontend/src/components/VizBuilder.tsx
@@ -2,7 +2,7 @@ import React, { useEffect, useState } from "react";
 import CategoryData from "../models/category_data";
 import QuestionData from "../models/question_data";
 import styles from "../stylesheets.module.scss";
-import { Divider, Row } from "antd";
+import { Row } from "antd";
 import CalendarViz from "./CalendarViz";
 import LineChartViz from "./LineChartViz";
 import Tooltip, { tooltipData } from "./Tooltip";
@@ -68,10 +68,7 @@ function VizBuilder(props: props) {
       {questionsForCategory.map((item) => {
         return (
           <div key={item.category}>
-            <Divider orientation="left" className={styles.divider}>
-              {" "}
-              {item.category}{" "}
-            </Divider>
+            <div className="section-label">{item.category}</div>
             <Row gutter={[16, 16]}>
               {item.questions.map((question) => {
                 if (question.graph_type === "line") {
@@ -105,7 +102,6 @@ function VizBuilder(props: props) {
                 }
               })}
             </Row>
-            <br />
             <br />
           </div>
         );

--- a/viz/frontend/src/index.css
+++ b/viz/frontend/src/index.css
@@ -1,21 +1,24 @@
-@import url('https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600&display=swap');
+@import url('https://fonts.googleapis.com/css2?family=Patrick+Hand&family=Caveat:wght@400;600&display=swap');
 
 * {
   box-sizing: border-box;
 }
 
-body {
+html, body {
   margin: 0;
-  font-family: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
-  -webkit-font-smoothing: antialiased;
-  -moz-osx-font-smoothing: grayscale;
-  background-color: #FAFAF8;
-  background-image: radial-gradient(circle, #d0cfc9 1px, transparent 1px);
-  background-size: 24px 24px;
+  padding: 0;
   min-height: 100vh;
-  color: #2c2c2c;
+  background: #ffffff;
 }
 
-code {
-  font-family: source-code-pro, Menlo, Monaco, Consolas, 'Courier New', monospace;
+body {
+  font-family: 'Patrick Hand', cursive;
+  -webkit-font-smoothing: antialiased;
+  color: #111;
+  background: #ffffff;
+}
+
+#root {
+  background: #ffffff;
+  min-height: 100vh;
 }

--- a/viz/frontend/src/index.css
+++ b/viz/frontend/src/index.css
@@ -1,13 +1,21 @@
+@import url('https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600&display=swap');
+
+* {
+  box-sizing: border-box;
+}
+
 body {
   margin: 0;
-  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto', 'Oxygen',
-    'Ubuntu', 'Cantarell', 'Fira Sans', 'Droid Sans', 'Helvetica Neue',
-    sans-serif;
+  font-family: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
+  background-color: #FAFAF8;
+  background-image: radial-gradient(circle, #d0cfc9 1px, transparent 1px);
+  background-size: 24px 24px;
+  min-height: 100vh;
+  color: #2c2c2c;
 }
 
 code {
-  font-family: source-code-pro, Menlo, Monaco, Consolas, 'Courier New',
-    monospace;
+  font-family: source-code-pro, Menlo, Monaco, Consolas, 'Courier New', monospace;
 }

--- a/viz/frontend/src/index.tsx
+++ b/viz/frontend/src/index.tsx
@@ -2,6 +2,9 @@ import React from 'react';
 import ReactDOM from 'react-dom/client';
 import './index.css';
 import App from './App';
+import { installMockFetch } from './mockFetch';
+
+installMockFetch();
 import reportWebVitals from './reportWebVitals';
 
 const root = ReactDOM.createRoot(

--- a/viz/frontend/src/index.tsx
+++ b/viz/frontend/src/index.tsx
@@ -2,9 +2,7 @@ import React from 'react';
 import ReactDOM from 'react-dom/client';
 import './index.css';
 import App from './App';
-import { installMockFetch } from './mockFetch';
-
-installMockFetch();
+import './mockFetch';
 import reportWebVitals from './reportWebVitals';
 
 const root = ReactDOM.createRoot(

--- a/viz/frontend/src/mockFetch.ts
+++ b/viz/frontend/src/mockFetch.ts
@@ -103,3 +103,6 @@ function mockResponse(data: unknown): Promise<Response> {
     headers: { 'Content-Type': 'application/json' },
   }));
 }
+
+// Auto-install at module load when env var is set (side-effect import)
+void (process.env.REACT_APP_USE_MOCK === 'true' && installMockFetch());

--- a/viz/frontend/src/mockFetch.ts
+++ b/viz/frontend/src/mockFetch.ts
@@ -1,0 +1,105 @@
+// Mock fetch for UI preview — intercepts API calls and returns dummy data
+
+const categories = ["Health", "Fitness", "Mood", "Sleep", "Productivity"];
+
+const questions: Record<string, Array<{key: string; display_name: string; graph_type: string; is_positive: boolean; is_reverse: boolean; min_value: number; max_value: number; cadence: string}>> = {
+  Health: [
+    { key: "whoopHRV", display_name: "HRV", graph_type: "line", is_positive: true, is_reverse: false, min_value: 0, max_value: 150, cadence: "daily" },
+    { key: "whoopRHR", display_name: "Resting Heart Rate", graph_type: "line", is_positive: false, is_reverse: true, min_value: 40, max_value: 100, cadence: "daily" },
+    { key: "whoopRecoveryScore", display_name: "Recovery Score", graph_type: "line", is_positive: true, is_reverse: false, min_value: 0, max_value: 100, cadence: "daily" },
+    { key: "whoopSpO2", display_name: "SpO2 %", graph_type: "line", is_positive: true, is_reverse: false, min_value: 90, max_value: 100, cadence: "daily" },
+  ],
+  Fitness: [
+    { key: "whoopStrain", display_name: "Strain", graph_type: "line", is_positive: true, is_reverse: false, min_value: 0, max_value: 21, cadence: "daily" },
+    { key: "running", display_name: "Running", graph_type: "calendar", is_positive: true, is_reverse: false, min_value: 0, max_value: 1, cadence: "daily" },
+    { key: "tricepCurl", display_name: "Tricep Curl", graph_type: "calendar", is_positive: true, is_reverse: false, min_value: 0, max_value: 1, cadence: "weekly" },
+  ],
+  Mood: [
+    { key: "mood", display_name: "Mood", graph_type: "line", is_positive: true, is_reverse: false, min_value: 1, max_value: 5, cadence: "daily" },
+    { key: "energy", display_name: "Energy", graph_type: "line", is_positive: true, is_reverse: false, min_value: 1, max_value: 5, cadence: "daily" },
+    { key: "stress", display_name: "Stress", graph_type: "line", is_positive: false, is_reverse: true, min_value: 1, max_value: 5, cadence: "daily" },
+  ],
+  Sleep: [
+    { key: "whoopSleepPerformance", display_name: "Sleep Performance", graph_type: "line", is_positive: true, is_reverse: false, min_value: 0, max_value: 100, cadence: "daily" },
+    { key: "whoopSleepEfficiency", display_name: "Sleep Efficiency", graph_type: "line", is_positive: true, is_reverse: false, min_value: 0, max_value: 100, cadence: "daily" },
+    { key: "sleptBefore1AM", display_name: "Slept Before 1AM", graph_type: "calendar", is_positive: true, is_reverse: false, min_value: 0, max_value: 1, cadence: "daily" },
+  ],
+  Productivity: [
+    { key: "deepWork", display_name: "Deep Work", graph_type: "line", is_positive: true, is_reverse: false, min_value: 0, max_value: 8, cadence: "daily" },
+    { key: "sugar", display_name: "Sugar", graph_type: "calendar", is_positive: false, is_reverse: true, min_value: 0, max_value: 1, cadence: "daily" },
+    { key: "veggies", display_name: "Veggies & Fruits", graph_type: "calendar", is_positive: true, is_reverse: false, min_value: 0, max_value: 1, cadence: "daily" },
+  ],
+};
+
+interface DataPoint { timestamp: string; value: number; }
+
+function generateTimeSeries(min: number, max: number, days = 90): DataPoint[] {
+  const result: DataPoint[] = [];
+  const now = new Date();
+  let val = (min + max) / 2;
+  for (let i = days; i >= 0; i--) {
+    const d = new Date(now);
+    d.setDate(d.getDate() - i);
+    val = Math.max(min, Math.min(max, val + (Math.random() - 0.48) * (max - min) * 0.12));
+    if (Math.random() > 0.15) {
+      result.push({ timestamp: d.toISOString(), value: Math.round(val * 10) / 10 });
+    }
+  }
+  return result;
+}
+
+function generateCalendarData(days = 90): DataPoint[] {
+  const result: DataPoint[] = [];
+  const now = new Date();
+  for (let i = days; i >= 0; i--) {
+    const d = new Date(now);
+    d.setDate(d.getDate() - i);
+    if (Math.random() > 0.25) {
+      result.push({ timestamp: d.toISOString(), value: Math.random() > 0.3 ? 1 : 0 });
+    }
+  }
+  return result;
+}
+
+const originalFetch = window.fetch.bind(window);
+
+export function installMockFetch() {
+  if (process.env.REACT_APP_USE_MOCK !== 'true') return;
+  window.fetch = async (input: RequestInfo | URL, init?: RequestInit): Promise<Response> => {
+    const url = typeof input === 'string' ? input : input.toString();
+
+    if (url.includes('/api/metadata')) {
+      return mockResponse({ name: "Soumyadeep" });
+    }
+
+    if (url.includes('/api/categories')) {
+      return mockResponse(categories.map(name => ({ name })));
+    }
+
+    if (url.includes('/api/questions')) {
+      const match = url.match(/category=([^&]*)/);
+      const cat = match ? decodeURIComponent(match[1]) : '';
+      return mockResponse((questions[cat] || []).map((q, i) => ({ ...q, order: i })));
+    }
+
+    if (url.includes('/api/data/')) {
+      const key = url.split('/api/data/')[1]?.split('?')[0];
+      const allQ = Object.values(questions).flat();
+      const q = allQ.find(x => x.key === key);
+      const isCalendar = q?.graph_type === 'calendar';
+      const data = isCalendar
+        ? generateCalendarData()
+        : generateTimeSeries(q?.min_value ?? 0, q?.max_value ?? 100);
+      return mockResponse({ data });
+    }
+
+    return originalFetch(input, init);
+  };
+}
+
+function mockResponse(data: unknown): Promise<Response> {
+  return Promise.resolve(new Response(JSON.stringify(data), {
+    status: 200,
+    headers: { 'Content-Type': 'application/json' },
+  }));
+}

--- a/viz/frontend/src/models/constants.ts
+++ b/viz/frontend/src/models/constants.ts
@@ -1,6 +1,6 @@
 export const viz_details ={
     viz_height: 200,
     viz_width: 350,
-    graph_line_width: 0.2,
+    graph_line_width: 0.8, // thicker axis lines for marker feel
 }
 


### PR DESCRIPTION
## Whiteboard-style UI for metrics dashboard

Redesigns the viz frontend with a handwritten/whiteboard aesthetic.

### Changes
- **Font**: Patrick Hand (Google Fonts) — clean handwritten style
- **Background**: Pure white, no grid, no border
- **Section labels**: Underlined, uppercase, marker-feel
- **Cards**: Thin pencil-sketch border, light layered shadow
- **Charts**: Thicker ink-style lines (blue for positive metrics, red for negative)
- **Mock data system**: `src/mockFetch.ts` intercepts fetch calls for UI preview — build with `REACT_APP_USE_MOCK=true` to preview without the live API

### Preview
https://sam17.github.io/FxLifeSheet/ (gh-pages branch, uses mock data)

### Note
`mockFetch.ts` is only activated in the mock build — production build uses the live API as before.